### PR TITLE
feat: allow groups to be defined and also extra keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13279,7 +13279,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -13295,19 +13295,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13322,7 +13322,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -13340,7 +13340,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -29917,7 +29917,7 @@
         "lodash._baseindexof": {
           "version": "3.1.0",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -29931,17 +29931,17 @@
         "lodash._bindcallback": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "dev": true,
+          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -29954,7 +29954,7 @@
         "lodash._getnative": {
           "version": "3.9.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -29969,7 +29969,7 @@
         "lodash.restparam": {
           "version": "3.6.1",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         },
         "lodash.union": {
           "version": "4.6.0",


### PR DESCRIPTION
Example:

```js
module.exports = {
  preset: "gerrit",
  groups: {
    default: {
      targets: [
        "docker-meta"
      ]
    }
  },
  targets: {
    "docker-meta": {
      images: ["felipecrs/docker-meta", "ghcr.io/felipecrs/docker-meta"],
      labels: {
        "org.label-schema.build-date": "docker-meta",
      },
      target: "build"
    },
  },
};
```
